### PR TITLE
Add swagger UI Automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.cache/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 BUF_VERSION:=v1.9.0
+SWAGGER_UI_VERSION:=v4.15.5
 
-generate:
+generate: generate/proto generate/swagger-ui
+generate/proto:
 	go run github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION) generate
+generate/swagger-ui:
+	SWAGGER_UI_VERSION=$(SWAGGER_UI_VERSION) ./scripts/generate-swagger-ui.sh
 
 lint:
 	go run github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION) lint

--- a/scripts/generate-swagger-ui.sh
+++ b/scripts/generate-swagger-ui.sh
@@ -41,4 +41,5 @@ cp -r "$CACHE_DIR/" "$GEN_DIR"
 # replace the default URL
 line="$(cat "$GEN_DIR/swagger-initializer.js" | grep -n "url" | cut -f1 -d:)"
 escaped_tmp="$(escape_str "$tmp")"
-sed -i '' -e "$line s/^.*$/$escaped_tmp/" "$GEN_DIR/swagger-initializer.js"
+sed -i'' -e "$line s/^.*$/$escaped_tmp/" "$GEN_DIR/swagger-initializer.js"
+rm -f "$GEN_DIR/swagger-initializer.js-e"

--- a/scripts/generate-swagger-ui.sh
+++ b/scripts/generate-swagger-ui.sh
@@ -17,7 +17,7 @@ if [[ ! -d "$CACHE_DIR" ]]; then
   mkdir -p "$CACHE_DIR"
   tmp="$(mktemp -d)"
   git clone --depth 1 --branch "$SWAGGER_UI_VERSION" "$SWAGGER_UI_GIT" "$tmp"
-  cp -r "$tmp/dist/" "$CACHE_DIR"
+  cp -r "$tmp/dist/"* "$CACHE_DIR"
   cp -r "$tmp/LICENSE" "$CACHE_DIR"
   rm -rf "$tmp"
 fi
@@ -36,7 +36,7 @@ tmp="$tmp],"
 # recreate swagger-ui, delete all except swagger.json
 find "$GEN_DIR" -type f -not -name "*.swagger.json" -delete
 mkdir -p "$GEN_DIR"
-cp -r "$CACHE_DIR/" "$GEN_DIR"
+cp -r "$CACHE_DIR/"* "$GEN_DIR"
 
 # replace the default URL
 line="$(cat "$GEN_DIR/swagger-initializer.js" | grep -n "url" | cut -f1 -d:)"

--- a/scripts/generate-swagger-ui.sh
+++ b/scripts/generate-swagger-ui.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -e
+
+[[ -z "$SWAGGER_UI_VERSION" ]] && echo "missing \$SWAGGER_UI_VERSION" && exit 1
+
+SWAGGER_UI_GIT="https://github.com/swagger-api/swagger-ui.git"
+CACHE_DIR="./.cache/swagger-ui/$SWAGGER_UI_VERSION"
+GEN_DIR="./third_party/OpenAPI"
+
+escape_str() {
+  echo "$1" | sed -e 's/[]\/$*.^[]/\\&/g'
+}
+
+# do caching if there's no cache yet
+if [[ ! -d "$CACHE_DIR" ]]; then
+  mkdir -p "$CACHE_DIR"
+  tmp="$(mktemp -d)"
+  git clone --depth 1 --branch "$SWAGGER_UI_VERSION" "$SWAGGER_UI_GIT" "$tmp"
+  cp -r "$tmp/dist/" "$CACHE_DIR"
+  cp -r "$tmp/LICENSE" "$CACHE_DIR"
+  rm -rf "$tmp"
+fi
+
+# populate swagger.json
+tmp="    urls: ["
+for i in $(find "$GEN_DIR" -name "*.swagger.json"); do
+  escaped_gen_dir="$(escape_str "$GEN_DIR/")"
+  path="$(echo $i | sed -e "s/$escaped_gen_dir//g")"
+  tmp="$tmp{\"url\":\"$path\",\"name\":\"$path\"},"
+done
+# delete last characters from $tmp
+tmp=$(echo "$tmp" | sed 's/.$//')
+tmp="$tmp],"
+
+# recreate swagger-ui, delete all except swagger.json
+find "$GEN_DIR" -type f -not -name "*.swagger.json" -delete
+mkdir -p "$GEN_DIR"
+cp -r "$CACHE_DIR/" "$GEN_DIR"
+
+# replace the default URL
+line="$(cat "$GEN_DIR/swagger-initializer.js" | grep -n "url" | cut -f1 -d:)"
+escaped_tmp="$(escape_str "$tmp")"
+sed -i '' -e "$line s/^.*$/$escaped_tmp/" "$GEN_DIR/swagger-initializer.js"

--- a/third_party/OpenAPI/swagger-initializer.js
+++ b/third_party/OpenAPI/swagger-initializer.js
@@ -1,9 +1,9 @@
-window.onload = function () {
+window.onload = function() {
   //<editor-fold desc="Changeable Configuration Block">
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    url: "./users/v1/users.swagger.json",
+    urls: [{"url":"users/v1/users.swagger.json","name":"users/v1/users.swagger.json"}],
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -12,4 +12,6 @@ of this repository. The static assets are copied from
 of the OpenAPI-UI project. After copying, [`swagger-initializer.js`](./OpenAPI/swagger-initializer.js)
 is edited to load the swagger file from the local server instead of the default petstore.
 
+The steps above can be done automatically by using `make generate/swagger-ui` which is executing [./scripts/generate-swagger-ui.sh](./scripts/generate-swagger-ui.sh). The script will clone the [OpenAPI repo](https://github.com/swagger-api/swagger-ui) with specific version defined by `$SWAGGER_UI_VERSION` and cache it at `./.cache/swagger-ui/$SWAGGER_UI_VERSION` so if the script is running twice using the same version it will use the cache right away.
+
 See the respective LICENSE files for each project for the applicable license terms.


### PR DESCRIPTION
Hi @johanbrandhorst, please help to review and merge this to automate the creation of swagger UI instead of copy-pasting manually

Changes:
- Add `make generate/swagger-ui` to automatically clone OpenAPI repo to refresh the Swagger UI
- Support multiple `swagger.json` files using `urls` instead of `url` at [`swagger-initializer.js`](./OpenAPI/swagger-initializer.js). [reference](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#core)