### PR TITLE
Fix GitHub Actions CI failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ generate/swagger-ui:
 
 lint:
 	go run github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION) lint
-	go run github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION) breaking --against 'https://github.com/johanbrandhorst/grpc-gateway-boilerplate.git#branch=master'
+	go run github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION) breaking --against 'https://github.com/johanbrandhorst/grpc-gateway-boilerplate.git#branch=main'

--- a/scripts/generate-swagger-ui.sh
+++ b/scripts/generate-swagger-ui.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-[[ -z "$SWAGGER_UI_VERSION" ]] && echo "missing \$SWAGGER_UI_VERSION" && exit 1
+[ -z "$SWAGGER_UI_VERSION" ] && echo "missing \$SWAGGER_UI_VERSION" && exit 1
 
 SWAGGER_UI_GIT="https://github.com/swagger-api/swagger-ui.git"
 CACHE_DIR="./.cache/swagger-ui/$SWAGGER_UI_VERSION"
@@ -13,7 +13,7 @@ escape_str() {
 }
 
 # do caching if there's no cache yet
-if [[ ! -d "$CACHE_DIR" ]]; then
+if [ ! -d "$CACHE_DIR" ]; then
   mkdir -p "$CACHE_DIR"
   tmp="$(mktemp -d)"
   git clone --depth 1 --branch "$SWAGGER_UI_VERSION" "$SWAGGER_UI_GIT" "$tmp"


### PR DESCRIPTION
This PR aims to address issue #44 

Things changed:
- Changed the second command in `make lint` to use the proper branch name
- Changed double brackets to single brackets in `generate-swagger-ui.sh` script since `#!/bin/sh` shebang is being used

The GitHub Actions workflow is all green in my forked repository so I think the changes are adequate.
With that said, if any further changes/improvements are required please let me know.